### PR TITLE
Remove the preparer container when it's done.

### DIFF
--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -183,6 +183,18 @@ var waitForCompletion = function (state) {
   };
 };
 
+var removePreparerContainer = function (state) {
+  return function (callback) {
+    state.whisper("Removing completed preparer container.", {
+      containerId: state.container.id
+    });
+
+    state.container.remove({}, function (err) {
+      callback(err);
+    });
+  };
+};
+
 exports.prepare = function (opts, callback) {
   var state = {
     root: opts.root,
@@ -201,7 +213,8 @@ exports.prepare = function (opts, callback) {
     createPreparerContainer(state),
     startPreparerContainer(state),
     preparerContainerLogs(state),
-    waitForCompletion(state)
+    waitForCompletion(state),
+    removePreparerContainer(state)
   ], function (err) {
     if (err) {
       state.say("Preparer completed with an error.", err);


### PR DESCRIPTION
This'll keep the Docker daemon from being cluttered with stopped preparers.

Fixes #2.
