### PR TITLE
Report failures correctly

### DIFF
--- a/lib/entry.js
+++ b/lib/entry.js
@@ -105,7 +105,7 @@ exports.recursivelyPrepare = function (opts, callback) {
     }
 
     if (!allSuccessful) {
-      return callback("At least one preparer run terminated unsuccessfully.", true);
+      return callback(new Error('At least one preparer run terminated unsuccessfully.'), true);
     }
 
     callback(null, {

--- a/worker.js
+++ b/worker.js
@@ -21,7 +21,10 @@ module.exports = {
           opts.whisper('Testing pull request [%s].', opts.pullRequestURL);
 
           entry.preparePullRequest(opts, function (err, results) {
-            if (err) return done(err);
+            if (err) {
+              err.type = 'exitCode';
+              err.code = 1;
+            }
 
             done(null, results.didSomething);
           });
@@ -34,9 +37,12 @@ module.exports = {
         var opts = assembleOptions(config, context);
 
         entry.recursivelyPrepare(opts, function (err, results) {
-          if (err) return done(err);
+          if (err) {
+            err.type = 'exitCode';
+            err.code = 1;
+          }
 
-          done(null, results.didSomething);
+          done(err, results.didSomething);
         });
       }
     });


### PR DESCRIPTION
Strider's job runners are biased a bit toward commands executed in subshells. Fake it out a bit to get the error status properly.

Fixes #17.
