### PR TITLE
Distinct prepare and submit phases

### DIFF
--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -35,6 +35,9 @@ exports.prepare = function (toolbelt, opts, callback) {
 
   var docker = toolbelt.docker;
 
+  var envelopeDir = path.join(opts.contentRoot, '_deconst/envelopes');
+  var assetDir = path.join(opts.contentRoot, '_deconst/assets');
+
   var readConfiguration = function (cb) {
     var filename = path.join(opts.contentRoot, '_deconst.json');
 
@@ -91,26 +94,10 @@ exports.prepare = function (toolbelt, opts, callback) {
     });
   };
 
-  var runPreparer = function (cb) {
-    var env = [
-      'CONTENT_STORE_URL=' + opts.contentServiceURL,
-      'CONTENT_STORE_APIKEY=' + opts.contentServiceAPIKey,
-      'TRAVIS_PULL_REQUEST=false'
-    ];
-
-    if (toolbelt.config.contentServiceTLSVerify === false) {
-      env.push('CONTENT_STORE_TLS_VERIFY=false');
+  var withContentRootMount = function (params) {
+    if (!params.HostConfig) {
+      params.HostConfig = {};
     }
-
-    if (contentIDBase) {
-      env.push('CONTENT_ID_BASE=' + contentIDBase);
-    }
-
-    var params = {
-      Image: preparer,
-      Env: env,
-      HostConfig: {}
-    };
 
     if (toolbelt.workspaceContainerRoot()) {
       params.HostConfig.VolumesFrom = [toolbelt.workspaceContainerRoot()];
@@ -128,12 +115,41 @@ exports.prepare = function (toolbelt, opts, callback) {
       params.HostConfig.Binds = [bind];
     }
 
+    return params;
+  };
+
+  var runPreparer = function (cb) {
+    var params = withContentRootMount({
+      Image: preparer,
+      Env: [
+        'ENVELOPE_DIR=' + envelopeDir,
+        'ASSET_DIR=' + assetDir,
+        'CONTENT_ID_BASE=' + contentIDBase
+      ]
+    });
+
+    docker.runContainer(params, cb);
+  }
+
+  var runSubmitter = function (cb) {
+    var params = withContentRootMount({
+      Image: 'quay.io/deconst/submitter',
+      Env: [
+        'CONTENT_SERVICE_URL=' + opts.contentServiceURL,
+        'CONTENT_SERVICE_APIKEY=' + opts.contentServiceAPIKey,
+        'ENVELOPE_DIR=' + envelopeDir,
+        'ASSET_DIR=' + assetDir,
+        'CONTENT_ID_BASE=' + contentIDBase
+      ]
+    });
+
     docker.runContainer(params, cb);
   }
 
   async.series([
     readConfiguration,
-    runPreparer
+    runPreparer,
+    runSubmitter
   ], function (err, results) {
     var result = { contentIDBase: contentIDBase };
 

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -35,8 +35,9 @@ exports.prepare = function (toolbelt, opts, callback) {
 
   var docker = toolbelt.docker;
 
-  var envelopeDir = path.join(opts.contentRoot, '_deconst/envelopes');
-  var assetDir = path.join(opts.contentRoot, '_deconst/assets');
+  var root = toolbelt.workspaceContainer() ? opts.contentRoot : '/usr/content-repo';
+  var envelopeDir = path.join(root, '_deconst/envelopes');
+  var assetDir = path.join(root, '_deconst/assets');
 
   var readConfiguration = function (cb) {
     var filename = path.join(opts.contentRoot, '_deconst.json');
@@ -50,10 +51,10 @@ exports.prepare = function (toolbelt, opts, callback) {
         return cb(new Error('Unable to parse _deconst.json'));
       }
 
-      if (opts.revisionID) {
-        if (config.contentIDBase) {
-          contentIDBase = config.contentIDBase;
+      if (config.contentIDBase) {
+        contentIDBase = config.contentIDBase;
 
+        if (opts.revisionID) {
           // Prepend the revision ID as the first path segment of the content ID.
           var u = url.parse(contentIDBase);
 
@@ -66,10 +67,10 @@ exports.prepare = function (toolbelt, opts, callback) {
 
           contentIDBase = url.format(u);
           toolbelt.debug('Revised content ID base: [%s]', contentIDBase);
-        } else {
-          toolbelt.error('No content ID base found in %s', filename);
-          return cb(new Error('No content ID base found in _deconst.json'));
         }
+      } else {
+        toolbelt.error('No content ID base found in %s', filename);
+        return cb(new Error('No content ID base found in _deconst.json'));
       }
 
       if (config.preparer) {
@@ -99,8 +100,8 @@ exports.prepare = function (toolbelt, opts, callback) {
       params.HostConfig = {};
     }
 
-    if (toolbelt.workspaceContainerRoot()) {
-      params.HostConfig.VolumesFrom = [toolbelt.workspaceContainerRoot()];
+    if (toolbelt.workspaceContainer()) {
+      params.HostConfig.VolumesFrom = [toolbelt.workspaceContainer()];
       params.Env.push("CONTENT_ROOT=" + opts.contentRoot);
     } else {
       var containerPath = '/usr/content-repo';
@@ -124,7 +125,8 @@ exports.prepare = function (toolbelt, opts, callback) {
       Env: [
         'ENVELOPE_DIR=' + envelopeDir,
         'ASSET_DIR=' + assetDir,
-        'CONTENT_ID_BASE=' + contentIDBase
+        'CONTENT_ID_BASE=' + contentIDBase,
+        'VERBOSE=' + (toolbelt.config.verbose ? 'true' : '')
       ]
     });
 
@@ -139,7 +141,8 @@ exports.prepare = function (toolbelt, opts, callback) {
         'CONTENT_SERVICE_APIKEY=' + opts.contentServiceAPIKey,
         'ENVELOPE_DIR=' + envelopeDir,
         'ASSET_DIR=' + assetDir,
-        'CONTENT_ID_BASE=' + contentIDBase
+        'CONTENT_ID_BASE=' + contentIDBase,
+        'VERBOSE=' + (toolbelt.config.verbose ? 'true' : '')
       ]
     });
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "dependencies": {
     "async": "1.5.2",
-    "strider-deconst-common": "0.0.1",
+    "strider-deconst-common": "0.0.2",
     "url-join": "0.0.1",
     "walk": "2.3.9"
   },


### PR DESCRIPTION
Pass `ENVELOPE_DIR` and `ASSET_DIR` to the preparer instead of the content service connection information, then run the submitter on its output.

Fixes #20.
