### PR TITLE
Interpret preparer and submitter exit statuses

### DIFF
--- a/lib/entry.js
+++ b/lib/entry.js
@@ -22,6 +22,7 @@ var recursivelyPrepare = exports.recursivelyPrepare = function (toolbelt, opts, 
 
   var atLeastOne = false
   var allSuccessful = true
+  var submittedSomething = false
   var contentIDMap = {}
 
   var walker = walk.walk(toolbelt.workspacePath(), options)
@@ -61,7 +62,10 @@ var recursivelyPrepare = exports.recursivelyPrepare = function (toolbelt, opts, 
         var relativeRoot = path.relative(toolbelt.workspacePath(), root)
 
         allSuccessful = allSuccessful && results.success
-        contentIDMap[relativeRoot] = results.contentIDBase
+        if (results.didSomething) {
+          submittedSomething = true
+          contentIDMap[relativeRoot] = results.contentIDBase
+        }
         callback(null)
       })
     } else {
@@ -81,18 +85,17 @@ var recursivelyPrepare = exports.recursivelyPrepare = function (toolbelt, opts, 
     toolbelt.debug('Walk completed')
 
     if (!atLeastOne) {
-      toolbelt.info('No preparable content discovered.')
+      toolbelt.info('No content discovered to prepare and submit.')
       toolbelt.info('Please add a _deconst.json file to each root directory where content is located.')
-
-      return callback(null, false)
     }
 
     if (!allSuccessful) {
-      return callback(new Error('At least one preparer run terminated unsuccessfully.'), true)
+      return callback(new Error('At least one preparer terminated unsuccessfully.'), true)
     }
 
     callback(null, {
-      didSomething: true,
+      didSomething: atLeastOne,
+      submittedSomething: submittedSomething,
       contentIDMap: contentIDMap
     })
   })
@@ -103,6 +106,7 @@ exports.preparePullRequest = function (toolbelt, callback) {
   var transientKey = null
   var contentIDMap = null
   var presentedURLMap = null
+  var submittedSomething = false
   var didSomething = false
 
   var stagingPresenter = toolbelt.stagingPresenter
@@ -150,6 +154,7 @@ exports.preparePullRequest = function (toolbelt, callback) {
     recursivelyPrepare(toolbelt, opts, function (err, result) {
       if (err) return cb(err)
 
+      submittedSomething = result.submittedSomething
       didSomething = result.didSomething
       contentIDMap = result.contentIDMap
       cb(null)
@@ -166,6 +171,7 @@ exports.preparePullRequest = function (toolbelt, callback) {
       toolbelt.error('Unable to comment on GitHub: the staging URL is not configured.')
       return cb(null)
     }
+    if (!submittedSomething) return cb(null)
 
     presentedURLMap = {}
 
@@ -188,6 +194,7 @@ exports.preparePullRequest = function (toolbelt, callback) {
 
   var commentOnGitHub = function (cb) {
     if (!presentedURLMap) return cb(null)
+    if (!submittedSomething) return cb(null)
 
     if (!github) {
       toolbelt.error('Unable to comment on GitHub: no GitHub account available.')

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -176,13 +176,13 @@ exports.prepare = function (toolbelt, opts, callback) {
     }
 
     if (err) {
-      toolbelt.error('Content submission failure.', err)
+      toolbelt.error('Oh no:', err)
       return callback(err, result)
     }
     result.success = true
 
     if (submitterStatus === 0) {
-      toolbelt.info('All content submitted successfully.')
+      toolbelt.info('All content prepared and submitted successfully.')
       result.didSomething = true
     } else if (submitterStatus === 2) {
       toolbelt.info('Nothing to submit.')

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -34,6 +34,8 @@ var preparerWhitelist = (function () {
 exports.prepare = function (toolbelt, opts, callback) {
   var contentIDBase = null
   var preparer = null
+  var preparerStatus = null
+  var submitterStatus = null
 
   var docker = toolbelt.docker
 
@@ -118,7 +120,17 @@ exports.prepare = function (toolbelt, opts, callback) {
       }
     }
 
-    docker.runContainer(params, cb)
+    docker.runContainer(params, function (err, result) {
+      if (err) return cb(err)
+
+      preparerStatus = result.status
+
+      if (preparerStatus !== 0) {
+        return cb(new Error('Preparer exitted with an error status ' + preparerStatus))
+      }
+      toolbelt.info('Preparer completed successfull.')
+      cb(null)
+    })
   }
 
   var runSubmitter = function (cb) {
@@ -139,27 +151,45 @@ exports.prepare = function (toolbelt, opts, callback) {
       }
     }
 
-    docker.runContainer(params, cb)
+    docker.runContainer(params, function (err, result) {
+      if (err) return cb(err)
+
+      submitterStatus = result.status
+
+      if (submitterStatus !== 0 && submitterStatus !== 2) {
+        return cb(new Error('Submitter exited with an error status ' + submitterStatus))
+      }
+      toolbelt.info('Submitter completed successfully.')
+      cb(null)
+    })
   }
 
   async.series([
     readConfiguration,
     runPreparer,
     runSubmitter
-  ], function (err, results) {
-    var result = { contentIDBase: contentIDBase }
-
-    if (err) {
-      toolbelt.error('Preparer completed with an error.', err)
-      result.success = false
-      return callback(err, result)
+  ], function (err) {
+    var result = {
+      contentIDBase: contentIDBase,
+      success: false,
+      didSomething: false
     }
 
-    toolbelt.info('Preparer completed.', {
-      status: results[1].status
-    })
+    if (err) {
+      toolbelt.error('Content submission failure.', err)
+      return callback(err, result)
+    }
+    result.success = true
 
-    result.success = results[1].status === 0
+    if (submitterStatus === 0) {
+      toolbelt.info('All content submitted successfully.')
+      result.didSomething = true
+    } else if (submitterStatus === 2) {
+      toolbelt.info('Nothing to submit.')
+    } else {
+      toolbelt.error('Unexpected exit code reported from submitter: ' + submitterStatus)
+    }
+
     callback(null, result)
   })
 }


### PR DESCRIPTION
Interpret and report abnormal exit statuses from the preparer and submitter containers. Pass failures of either as build failures in Strider. Interpret an exit of 2 from the submitter as "nothing changed" and omit the preview comment.

Fixes #26.
