### PR TITLE
Clear envelope and asset output directories before use

### DIFF
--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -4,6 +4,7 @@ var fs = require('fs')
 var path = require('path')
 var url = require('url')
 var async = require('async')
+var rimraf = require('rimraf')
 
 var heuristic = require('./heuristic')
 
@@ -104,6 +105,10 @@ exports.prepare = function (toolbelt, opts, callback) {
     })
   }
 
+  var clearOutputDirectories = function (cb) {
+    async.each([envelopeDir, assetDir], function (dir, cb) { rimraf(dir, cb) }, cb)
+  }
+
   var runPreparer = function (cb) {
     var params = {
       Image: preparer,
@@ -166,6 +171,7 @@ exports.prepare = function (toolbelt, opts, callback) {
 
   async.series([
     readConfiguration,
+    clearOutputDirectories,
     runPreparer,
     runSubmitter
   ], function (err) {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "license": "MIT",
   "dependencies": {
     "async": "1.5.2",
+    "rimraf": "2.5.2",
     "strider-deconst-common": "0.0.3",
     "url-join": "0.0.1",
     "walk": "2.3.9"


### PR DESCRIPTION
Strider appears to be re-using `ENVELOPES_DIR` and `ASSET_DIR` across builds somehow: compare [this PR build](https://build.deconst.horse/deconst/deconst-docs/job/57225bbd203586010097f133) with [this one, which was triggered immediately after a cache clear](https://build.deconst.horse/deconst/deconst-docs/job/57226f14203586010097f13c). This is causing PR builds to falsely believe that they have new envelopes to submit and would interfere with the ability to delete pages.

Related to #30.
