### PR TITLE
updating messages to indicate staging link expiration

### DIFF
--- a/lib/comment.js
+++ b/lib/comment.js
@@ -1,3 +1,5 @@
+/* jshint node: true, esversion: 6, asi: true*/
+
 'use strict'
 
 // Use a variety of templates for the pull request comment to mix it up a bit.
@@ -84,6 +86,9 @@ exports.forSuccessfulBuild = function (urlMap) {
   if (hasUnmapped) {
     message += '\n\n' + mappingHelp
   }
+
+  message += '\n\n'
+  message += 'This staging link will expire in 30 days.'
 
   return message
 }


### PR DESCRIPTION
Part of deconst/content-service#87 and rackerlabs/docs-workstream#263

Add in a warning to the comments that get posted by Strider to indicate the staging links will expire.